### PR TITLE
feat: add --validate flag to check policy YAML without evaluating

### DIFF
--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -23,16 +23,46 @@ func LoadPolicy(filePath string) (*types.Policy, error) {
 	if len(policy.SafetyTiers) == 0 {
 		return nil, fmt.Errorf("invalid policy: at least one safety_tier is required")
 	}
+	tierNames := make(map[string]bool)
+	for i, tier := range policy.SafetyTiers {
+		if tier.Name == "" {
+			return nil, fmt.Errorf("invalid policy: safety_tier at index %d is missing a name", i)
+		}
+		if tierNames[tier.Name] {
+			return nil, fmt.Errorf("invalid policy: duplicate safety_tier name found: '%s'", tier.Name)
+		}
+		tierNames[tier.Name] = true
+	}
+
 	if len(policy.Roles) == 0 {
 		return nil, fmt.Errorf("invalid policy: at least one role is required")
 	}
-	if len(policy.Resources) == 0 {
-		return nil, fmt.Errorf("invalid policy: at least one resource is required")
-	}
-	for _, role := range policy.Roles {
+	roleNames := make(map[string]bool)
+	for i, role := range policy.Roles {
+		if role.Name == "" {
+			return nil, fmt.Errorf("invalid policy: role at index %d is missing a name", i)
+		}
+		if roleNames[role.Name] {
+			return nil, fmt.Errorf("invalid policy: duplicate role name found: '%s'", role.Name)
+		}
 		if role.MaxTier == "" {
 			return nil, fmt.Errorf("invalid policy: role '%s' must define max_tier", role.Name)
 		}
+		roleNames[role.Name] = true
+	}
+
+	if len(policy.Resources) == 0 {
+		return nil, fmt.Errorf("invalid policy: at least one resource is required")
+	}
+	resourceNames := make(map[string]bool)
+	for i, resource := range policy.Resources {
+		if resource.Name == "" {
+			return nil, fmt.Errorf("invalid policy: resource at index %d is missing a name", i)
+		}
+		if resourceNames[resource.Name] {
+			return nil, fmt.Errorf("invalid policy: duplicate resource name found: '%s'", resource.Name)
+		}
+		resourceNames[resource.Name] = true
 	}
 
 	return &policy, nil

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -113,3 +113,25 @@ resources:
 		})
 	}
 }
+
+func TestLoadPolicyValid(t *testing.T) {
+	content := `
+safety_tiers:
+  - name: read_only
+roles:
+  - name: admin
+    max_tier: read_only
+resources:
+  - name: db
+`
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "policy.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write policy file: %v", err)
+	}
+
+	_, err := LoadPolicy(path)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -1,0 +1,115 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadPolicyValidation(t *testing.T) {
+	tests := []struct {
+		name          string
+		content       string
+		expectedError string
+	}{
+		{
+			name: "missing safety_tier name",
+			content: `
+safety_tiers:
+  - requires_approval: true
+roles:
+  - name: admin
+    max_tier: autonomous_write
+resources:
+  - name: db
+`,
+			expectedError: "safety_tier at index 0 is missing a name",
+		},
+		{
+			name: "duplicate safety_tier name",
+			content: `
+safety_tiers:
+  - name: read_only
+  - name: read_only
+roles:
+  - name: admin
+    max_tier: autonomous_write
+resources:
+  - name: db
+`,
+			expectedError: "duplicate safety_tier name found: 'read_only'",
+		},
+		{
+			name: "missing role name",
+			content: `
+safety_tiers:
+  - name: read_only
+roles:
+  - max_tier: autonomous_write
+resources:
+  - name: db
+`,
+			expectedError: "role at index 0 is missing a name",
+		},
+		{
+			name: "duplicate role name",
+			content: `
+safety_tiers:
+  - name: read_only
+roles:
+  - name: admin
+    max_tier: autonomous_write
+  - name: admin
+    max_tier: read_only
+resources:
+  - name: db
+`,
+			expectedError: "duplicate role name found: 'admin'",
+		},
+		{
+			name: "missing resource name",
+			content: `
+safety_tiers:
+  - name: read_only
+roles:
+  - name: admin
+    max_tier: autonomous_write
+resources:
+  - requires_approval: true
+`,
+			expectedError: "resource at index 0 is missing a name",
+		},
+		{
+			name: "duplicate resource name",
+			content: `
+safety_tiers:
+  - name: read_only
+roles:
+  - name: admin
+    max_tier: autonomous_write
+resources:
+  - name: db
+  - name: db
+`,
+			expectedError: "duplicate resource name found: 'db'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			path := filepath.Join(tmpDir, "policy.yaml")
+			if err := os.WriteFile(path, []byte(tt.content), 0o644); err != nil {
+				t.Fatalf("failed to write policy file: %v", err)
+			}
+
+			_, err := LoadPolicy(path)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if err.Error() != "invalid policy: "+tt.expectedError {
+				t.Fatalf("expected error 'invalid policy: %s', got '%v'", tt.expectedError, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a new CLI command  which supports a  flag. When set, it loads and validates the policy YAML file and exits with code 0 if valid, or code 1 if invalid.

Closes #1